### PR TITLE
feat(night_mode): Force set  background styles in NightMode

### DIFF
--- a/v2excellent.js
+++ b/v2excellent.js
@@ -19,6 +19,13 @@ var POST_PROCESS_FUNCS = [
   },
 ];
 
+//Fix night mode
+var divWrapper = document.getElementById("Wrapper");
+if(divWrapper.className == 'Night'){
+    divWrapper.style.backgroundColor ='#00000000';
+    divWrapper.style.backgroundImage ="url('/static/img/shadow.png'), url('//static.v2ex.com/bgs/pixels.png')";
+}
+
 // markdown-it 初始化
 var md = window.markdownit({
     html: true,


### PR DESCRIPTION
I saw that when V2ex in NightMode , the background image and color of some nodes' articles is still too bright, so I tried to set the background-styles in NightMode.

Sorry, I code in JavaScript infrequently , maybe the code is bad : )